### PR TITLE
Fix Netlify config syntax

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -15,16 +15,26 @@
     X-Content-Type-Options = "nosniff"
 
 [[headers]]
-  for = "/.*\\.css$"
+  for = "/*.css"
   [headers.values]
     Cache-Control = "public, max-age=31536000"
 
 [[headers]]
-  for = "/.*\\.(jpeg|jpg|png)$"
+  for = "/*.jpeg"
   [headers.values]
     Cache-Control = "public, max-age=31536000"
 
 [[headers]]
-  for = "/.*\\.html$"
+  for = "/*.jpg"
+  [headers.values]
+    Cache-Control = "public, max-age=31536000"
+
+[[headers]]
+  for = "/*.png"
+  [headers.values]
+    Cache-Control = "public, max-age=31536000"
+
+[[headers]]
+  for = "/*.html"
   [headers.values]
     Cache-Control = "public, max-age=0, must-revalidate"


### PR DESCRIPTION
## Summary
- use glob patterns for headers in Netlify config to avoid parse errors

## Testing
- `npm test` (fails: Missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68919decc390832a80b7e383998ec2fb